### PR TITLE
Remove stars from the skybox above 5000

### DIFF
--- a/skybox.lua
+++ b/skybox.lua
@@ -65,6 +65,7 @@ minetest.register_globalstep(function(dtime)
             player:set_sky(normal_sky)
             player:set_moon({visible = true})
             player:set_sun({visible = true})
+            player:set_stars({visible = true})
 			player_list[name] = "earth"
 			if otherworlds.settings.gravity.enable then
 				player:set_physics_override({gravity = 1})

--- a/skybox.lua
+++ b/skybox.lua
@@ -81,6 +81,7 @@ minetest.register_globalstep(function(dtime)
             })
             player:set_sun({visible = false, sunrise_visible = false})
             player:set_moon({visible = false})
+            player:set_stars({visible = false})
 			player_list[name] = "space"
 			if otherworlds.settings.gravity.enable then
 				player:set_physics_override({gravity = 0.4})
@@ -97,6 +98,7 @@ minetest.register_globalstep(function(dtime)
             })
             player:set_sun({visible = false, sunrise_visible = false})
             player:set_moon({visible = false})
+            player:set_stars({visible = false})
 			player_list[name] = "redsky"
 			if otherworlds.settings.gravity.enable then
 				player:set_physics_override({gravity = 0.2})
@@ -111,6 +113,7 @@ minetest.register_globalstep(function(dtime)
             })
             player:set_sun({visible = false, sunrise_visible = false})
             player:set_moon({visible = false})
+            player:set_stars({visible = false})
 			player_list[name] = "blackness"
 			if otherworlds.settings.gravity.enable then
 				player:set_physics_override({gravity = 0.1})


### PR DESCRIPTION
Uses `player:set_stars` to switch stars off in space above 5000